### PR TITLE
fix torch error

### DIFF
--- a/fireredasr/models/fireredasr.py
+++ b/fireredasr/models/fireredasr.py
@@ -107,7 +107,7 @@ class FireRedAsr:
 
 
 def load_fireredasr_aed_model(model_path):
-    package = torch.load(model_path, map_location=lambda storage, loc: storage)
+    package = torch.load(model_path, weights_only=False, map_location=lambda storage, loc: storage)
     print("model args:", package["args"])
     model = FireRedAsrAed.from_args(package["args"])
     model.load_state_dict(package["model_state_dict"], strict=True)
@@ -115,7 +115,7 @@ def load_fireredasr_aed_model(model_path):
 
 
 def load_firered_llm_model_and_tokenizer(model_path, encoder_path, llm_dir):
-    package = torch.load(model_path, map_location=lambda storage, loc: storage)
+    package = torch.load(model_path, weights_only=False, map_location=lambda storage, loc: storage)
     package["args"].encoder_path = encoder_path
     package["args"].llm_dir = llm_dir
     print("model args:", package["args"])


### PR DESCRIPTION
fixes error:
```shell
torch/serialization.py", line 1470, in load
    raise pickle.UnpicklingError(_get_wo_message(str(e))) from None
_pickle.UnpicklingError: Weights only load failed. This file can still be loaded, to do so you have two options, do those steps only if you trust the source of the checkpoint. 
	(1) In PyTorch 2.6, we changed the default value of the `weights_only` argument in `torch.load` from `False` to `True`. Re-running `torch.load` with `weights_only` set to `False` will likely succeed, but it can result in arbitrary code execution. Do it only if you got the file from a trusted source.
```