### PR TITLE
[ROCm] Add Torch SDPA and xFormers optimization for FireRedASR

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,31 @@ print(results)
 - FireRedASR-AED supports audio input up to 60s. Input longer than 60s may cause hallucination issues, and input exceeding 200s will trigger positional encoding errors.
 - FireRedASR-LLM supports audio input up to 30s. The behavior for longer input is currently unknown.
 
+## FireRedASR-AED Optimization with ROCm
+1. Build docker image with `docker/Dockerfile.rocm` to setup environemt
+```
+docker build --network=host -f docker/Dockerfile.rocm -t rocm/firered-asr-opt
+```
+
+2. Launch docker container
+```
+docker run -it  --ipc=host --network=host --privileged --security-opt seccomp=unconfined --cap-add=CAP_SYS_ADMIN --cap-add=SYS_PTRACE --device=/dev/kfd --device=/dev/dri --device=/dev/mem rocm/firered-asr-opt
+```
+
+3. Run performance test with native MHA (baseline)
+```python
+ATTENTION_BACKEND="NATIVE" python example/benchmark_firered_asr.py
+```
+
+4. Run performance test with MHA using torch SDPA
+```python
+ATTENTION_BACKEND="SDPA" python example/benchmark_firered_asr.py
+```
+
+5. Run performance test with MHA using xFormers
+```python
+ATTENTION_BACKEND="XFORMERS" python example/benchmark_firered_asr.py
+```
 
 ## Acknowledgements
 Thanks to the following open-source works:

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ print(results)
 - FireRedASR-AED supports audio input up to 60s. Input longer than 60s may cause hallucination issues, and input exceeding 200s will trigger positional encoding errors.
 - FireRedASR-LLM supports audio input up to 30s. The behavior for longer input is currently unknown.
 
-## FireRedASR-AED Optimization with ROCm
+### FireRedASR-AED Optimization with ROCm
 1. Build docker image with `docker/Dockerfile.rocm` to setup environemt
 ```
 docker build --network=host -f docker/Dockerfile.rocm -t rocm/firered-asr-opt
@@ -153,17 +153,17 @@ docker run -it  --ipc=host --network=host --privileged --security-opt seccomp=un
 
 3. Run performance test with native MHA (baseline)
 ```python
-ATTENTION_BACKEND="NATIVE" python example/benchmark_firered_asr.py
+ATTENTION_BACKEND="NATIVE" python examples/benchmark_firered_asr.py
 ```
 
 4. Run performance test with MHA using torch SDPA
 ```python
-ATTENTION_BACKEND="SDPA" python example/benchmark_firered_asr.py
+ATTENTION_BACKEND="SDPA" python examples/benchmark_firered_asr.py
 ```
 
 5. Run performance test with MHA using xFormers
 ```python
-ATTENTION_BACKEND="XFORMERS" python example/benchmark_firered_asr.py
+ATTENTION_BACKEND="XFORMERS" python examples/benchmark_firered_asr.py
 ```
 
 ## Acknowledgements

--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -1,0 +1,28 @@
+ARG BASE_IMAGE=rocm/pytorch:rocm7.0.2_ubuntu24.04_py3.12_pytorch_release_2.8.0
+FROM ${BASE_IMAGE} AS base
+
+ARG PYTORCH_ROCM_ARCH=gfx942
+ENV PYTORCH_ROCM_ARCH=${PYTORCH_ROCM_ARCH}
+ENV HIP_ARCHITECTURE=${PYTORCH_ROCM_ARCH}
+ENV ROCM_PATH=/opt/rocm
+ENV XFORMERS_CK_FLASH_ATTN=1
+ARG PYTHON_VERSION=3.12
+ENV DEBIAN_FRONTEND=noninteractive
+
+WORKDIR /root
+
+RUN set -ex && usermod -a -G video $(whoami)
+
+RUN python3 -m pip install -U packaging 'cmake<4' ninja wheel 'setuptools<80' pybind11 Cython
+
+RUN git clone https://github.com/FireRedTeam/FireRedASR /root/FireRedASR \ 
+    && cd /root/FireRedASR \
+    && python3 -m pip install -r requirements.txt
+
+RUN git clone https://github.com/ROCm/xformers.git /root/xformers \
+    && cd /root/xformers \
+    && git checkout 5f0419a \
+    && git submodule update --init --recursive \
+    && PYTORCH_ROCM_ARCH=$PYTORCH_ROCM_ARCH HIP_ARCHITECTURE=$HIP_ARCHITECTURE XFORMERS_CK_FLASH_ATTN=$XFORMERS_CK_FLASH_ATTN python3 setup.py install
+
+WORKDIR /root/FireRedASR

--- a/examples/benchmark_firered_asr.py
+++ b/examples/benchmark_firered_asr.py
@@ -21,7 +21,7 @@ ATTENTION_BACKEND = os.environ.get("ATTENTION_BACKEND", "XFORMERS") # Option: "N
 def load_model(model_path="pretrained_models/FireRedASR-AED-L"):
     print("==========Load model:========")
     model = FireRedAsr.from_pretrained("aed", model_path)
-    model.model.half()
+    model.model.to(torch.bfloat16)
     model.model.cuda()
     model.model.eval()
 
@@ -35,15 +35,41 @@ def load_audio(wav_path):
         audio = librosa.resample(audio, orig_sr=sr, target_sr=16000)
     return audio
 
-def benchmark(model, wav_path, batch, warmpup=2, trials=10, enable_profile=False):
-    batch_wav_path = [wav_path] * batch
+def benchmark(model, audio_dir, batch, warmpup=2, trials=10, enable_profile=False):
+    # Get list of .wav files (case-insensitive)
+    batch_wav_path = []
+
+    # Collect file paths and durations
+    file_durations = []
+    input_wav_path_list = [os.path.join(audio_dir, f)
+                        for f in os.listdir(audio_dir)
+                        if f.lower().endswith('.wav')]
+
+    for file_path in input_wav_path_list:
+        try:
+            y, sr = librosa.load(file_path, sr=None)  # keep original sampling rate
+            duration = len(y) / sr
+            file_durations.append((file_path, duration))
+        except Exception as e:
+            print(f"Error processing {file_path}: {e}")
+
+    # Sort by duration (longest first)
+    file_durations.sort(key=lambda x: x[1], reverse=True)
+
+    # Take top N for batch
+    batch_wav_path = [fp for fp, dur in file_durations[:batch]]
+
+    # Optional: print results
+    for i, (fp, dur) in enumerate(file_durations[:batch], start=1):
+        print(f"{i}. {fp} - {dur:.2f} sec")
+
     batch_uttid = list(range(batch))
     results = None
     total_dur = None
  
     preprocess_start = time.time()
     feats, lengths, durs = model.feat_extractor(batch_wav_path)
-    feats = feats.half()
+    feats = feats.to(torch.bfloat16)
     feats, lengths = feats.cuda(), lengths.cuda()
     preprocess_dur = time.time() - preprocess_start
     print(f"preprocess duration: {preprocess_dur:.3f} s")
@@ -93,10 +119,11 @@ def benchmark(model, wav_path, batch, warmpup=2, trials=10, enable_profile=False
 
     avg_latency = total_time / trials
     rps = batch / avg_latency
-    # Only print first result for debug purpose
-    print("results[0]: ", results[0])
-    #for res in results:
-        #print(res)
+    #Only print last result for debug purpose
+    #print("results[0]: ", results[0])
+    print("Only print last run results for debug purpose...")
+    for res in results[-batch:]:
+        print(res)
     avg_rtf = sum(rtf_list) / len(rtf_list)
     return rps, avg_latency, avg_rtf
 
@@ -104,11 +131,11 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(prog='Benchmark scripts for FireRedASR', usage='%(prog)s [options]')
     parser.add_argument('-b', '--batch_sizes', type=int, nargs='+', default=1, help='List of batch sizes for performance evaluation')
     parser.add_argument('-m', '--model_path', type=str, default="pretrained_models/FireRedASR-AED-L", help='Path to model directory')
-    parser.add_argument('-a', '--audio_path', type=str, default='examples/wav/TEST_MEETING_T0000000001_S00000.wav', help="Input audio path")
+    parser.add_argument('-a', '--audio_dir', type=str, default='examples/wav', help="Path to input audio directory")
     parser.add_argument('-d', '--device', type=str, default='cuda', help="Target inference device")
     parser.add_argument('-p', '--profile', action='store_true', help='Enable torch profiler')
     args = parser.parse_args()
-    audio_path = args.audio_path
+    audio_dir = args.audio_dir
     model_path = args.model_path
     device = args.device
     enable_profile = args.profile
@@ -116,9 +143,9 @@ if __name__ == "__main__":
     model = load_model(model_path)
     
     if enable_profile:
-        rps, avg_rtf, avg_latency = benchmark(model, audio_path, batch=1, enable_profile=True)
+        rps, avg_rtf, avg_latency = benchmark(model, audio_dir, batch=1, enable_profile=True)
     else:            
         for batch in batch_sizes:
             print(f"*************************** batch size {batch} ***************************")
-            rps, avg_latency, avg_rtf = benchmark(model, audio_path, batch=batch)
+            rps, avg_latency, avg_rtf = benchmark(model, audio_dir, batch=batch)
             print(f"batch size: {batch}, average latency: {avg_latency:.3f}s | RPS: {rps:.2f}, avg RTF: {avg_rtf:.3f}")

--- a/examples/benchmark_firered_asr.py
+++ b/examples/benchmark_firered_asr.py
@@ -1,0 +1,115 @@
+import os
+import time
+import torch
+import numpy as np
+from tqdm import tqdm
+
+import librosa
+import soundfile as sf
+import argparse
+import torch
+
+from fireredasr.models.fireredasr import FireRedAsr
+
+from torch.profiler import profile as torch_profiler
+from torch.profiler import ProfilerActivity, record_function
+
+
+ATTENTION_BACKEND = os.environ.get("ATTENTION_BACKEND", "XFORMERS") # Option: "NATIVE", "SDPA", "XFORMERS"
+
+
+def load_model(model_path="pretrained_models/FireRedASR-AED-L"):
+    print("==========Load model:========")
+    model = FireRedAsr.from_pretrained("aed", model_path)
+    model.model.half()
+    model.model.cuda()
+    model.model.eval()
+
+    return model
+
+def load_audio(wav_path):
+    print("==========load audio:=========")
+    audio, sr = sf.read(wav_path,dtype=np.float32)
+    print(len(audio), audio.dtype)
+    if sr != 16000:
+        audio = librosa.resample(audio, orig_sr=sr, target_sr=16000)
+    return audio
+
+def benchmark(model, wav_path, batch, warmpup=2, trials=10, enable_profile=False):
+    batch_wav_path = [wav_path] * batch
+    batch_uttid = list(range(batch))
+    results = None
+    total_dur = None
+ 
+    preprocess_start = time.time()
+    feats, lengths, durs = model.feat_extractor(batch_wav_path)
+    feats = feats.half()
+    feats, lengths = feats.cuda(), lengths.cuda()
+    preprocess_dur = time.time() - preprocess_start
+    print(f"preprocess_dur: {preprocess_dur:.3f} s")
+    total_dur = sum(durs)
+
+    # Warmup
+    print("==========warmup========")
+    for _ in range(warmpup):
+        with torch.no_grad():
+            _ = model.model.transcribe(feats, lengths)
+
+    # Benchmark
+    print("==========start benchmark========")
+    total_time = 0
+    results = []
+    rtf_list = []
+    if enable_profile: 
+        warmup=1
+        trials=1
+    for _ in tqdm(range(trials)):
+        start = time.time()
+        with torch.no_grad():
+            if enable_profile:
+                with torch_profiler(activities=[
+                    ProfilerActivity.CPU, 
+                    ProfilerActivity.CUDA], 
+                    record_shapes=True, 
+                    with_stack=True,
+                    profile_memory=False) as prof:
+                    #with record_function("model.model.transcribe"):
+                    hyps = model.model.transcribe(feats, lengths)
+                print(prof.key_averages().table(sort_by="cuda_time_total"))
+                prof.export_chrome_trace(f"firered_asr_profile_{batch}_{ATTENTION_BACKEND}.json")
+            else:
+                hyps = model.model.transcribe(feats, lengths)
+        total_time += time.time() - start
+        elapsed = time.time() - start
+
+        rtf = elapsed / total_dur if total_dur > 0 else 0
+        for uttid, wav, hyp in zip(batch_uttid, batch_wav_path, hyps):
+            hyp = hyp[0]  # only return 1-best
+            hyp_ids = [int(id) for id in hyp["yseq"].cpu()]
+            text = model.tokenizer.detokenize(hyp_ids)
+            results.append({"uttid": uttid, "text": text, "wav": wav,
+                "rtf": f"{rtf:.4f}"})
+        rtf_list.append(rtf)
+
+    avg_latency = total_time / trials
+    rps = batch / avg_latency
+    for res in results:
+        print(res)
+    avg_rtf = sum(rtf_list) / len(rtf_list)
+    return rps, avg_rtf
+
+if __name__ == "__main__":
+    audio_path = "examples/wav/TEST_MEETING_T0000000001_S00000.wav"
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    model_path = "pretrained_models/FireRedASR-AED-L"
+    enable_profile = False
+    batch_sizes = [1]
+    model = load_model(model_path)
+    
+    if enable_profile:
+        rps, avg_rtf = benchmark(model, audio_path, batch=1, enable_profile=True)
+    else:            
+        for batch in batch_sizes:
+            print(f"=============== batch size {batch} ==========================")
+            rps, avg_rtf = benchmark(model, audio_path, batch=batch)
+            print(f"batch size: {batch}, average latency: {1.0/rps:.3f}s | RPS: {rps:.2f}, avg RTF: {avg_rtf:.3f}")

--- a/fireredasr/models/fireredasr.py
+++ b/fireredasr/models/fireredasr.py
@@ -107,7 +107,7 @@ class FireRedAsr:
 
 
 def load_fireredasr_aed_model(model_path):
-    package = torch.load(model_path, map_location=lambda storage, loc: storage)
+    package = torch.load(model_path, map_location=lambda storage, loc: storage, weights_only=False)
     print("model args:", package["args"])
     model = FireRedAsrAed.from_args(package["args"])
     model.load_state_dict(package["model_state_dict"], strict=True)

--- a/fireredasr/models/module/transformer_decoder.py
+++ b/fireredasr/models/module/transformer_decoder.py
@@ -9,7 +9,6 @@ import os
 
 try:
     import xformers.ops as xops
-    from xformers.ops.fmha.attn_bias import BlockDiagonalMask, BlockDiagonalCausalMask
     xformers_available = True
 except Exception as e:
     xformers_available = False
@@ -224,7 +223,7 @@ class DecoderLayer(nn.Module):
 
 
 class DecoderMultiHeadAttention(nn.Module):
-    def __init__(self, d_model, n_head, dropout=0.1):
+    def __init__(self, d_model, n_head, dropout=0.1, attention_type=None):
         super().__init__()
         self.d_model = d_model
         self.n_head = n_head
@@ -245,7 +244,7 @@ class DecoderMultiHeadAttention(nn.Module):
             if not xformers_available:
                 print("ATTENTION_BACKEND='XFORMERS' selected, but the xformers package is not available. Please install xformers")
                 exit(1)
-            self.attention = DecoderXFormersAttention(self.n_head, self.d_k, self.d_model, temperature=self.d_k ** 0.5)
+            self.attention = DecoderXFormersAttention(self.n_head, self.d_k, self.d_model, temperature=self.d_k ** 0.5, attention_type=attention_type)
         else:
             print("Unsupported attention backend: ", ATTENTION_BACKEND)
             exit(1)
@@ -258,6 +257,9 @@ class DecoderMultiHeadAttention(nn.Module):
         q = self.w_qs(q).view(bs, -1, self.n_head, self.d_k)
         k = self.w_ks(k).view(bs, -1, self.n_head, self.d_k)
         v = self.w_vs(v).view(bs, -1, self.n_head, self.d_k)
+        q = q.transpose(1, 2)
+        k = k.transpose(1, 2)
+        v = v.transpose(1, 2)
 
         if mask is not None:
             mask = mask.unsqueeze(1)
@@ -279,9 +281,6 @@ class DecoderScaledDotProductAttention(nn.Module):
         self.INF = float("inf")
 
     def forward(self, q, k, v, mask=None):
-        q = q.transpose(1, 2)
-        k = k.transpose(1, 2)
-        v = v.transpose(1, 2)
         attn = torch.matmul(q, k.transpose(2, 3)) / self.temperature
         if mask is not None:
             mask = mask.eq(0)
@@ -303,9 +302,6 @@ class DecoderTorchSDPA(nn.Module):
 
     def forward(self, q, k, v, mask=None):
         bs = q.size(0)
-        q = q.transpose(1, 2)
-        k = k.transpose(1, 2)
-        v = v.transpose(1, 2)
         output = None
         if bs == 1:
             output = F.scaled_dot_product_attention(
@@ -325,60 +321,92 @@ class DecoderTorchSDPA(nn.Module):
         return output
 
 
+class XFormersAttentionMetadata:
+    """Metadata for XFormers Attention backend """
+    def __init__(self, attention_type):
+        self.attention_type = attention_type
+        self.attn_bias = None
+
+    def set_self_attn_bias(self):
+        if self.attention_type == "self_attention":
+            self.attn_bias = xops.LowerTriangularMask()
+        else:
+            print("Unknown attention type used, only support `self_attention`")
+
+    def set_cross_attn_bias(self, mask, bs, q_len, k_len):
+        if self.attention_type == "cross_attention":
+            mask = mask.to(torch.bool)
+
+            # If mask only has 1 in q_len dimension, expand it
+            if mask.size(2) == 1 and q_len > 1:
+                mask = mask.expand(bs, 1, q_len, k_len)
+
+            # Expand mask for all heads
+            mask = mask.expand(bs, self.n_head, q_len, k_len) \
+                    .reshape(bs * self.n_head, q_len, k_len)
+
+            # Alignment requirement for xformers: pad allocation to multiple of 8
+            pad_k = ((k_len + 7) // 8) * 8
+            pad_q = ((q_len + 7) // 8) * 8
+
+            bias_full = torch.zeros(bs * self.n_head, pad_q, pad_k,
+                                    dtype=q.dtype, device=q.device)
+
+            bias_full[:, :q_len, :k_len].masked_fill_(~mask, float("-inf"))
+
+            # Slice down to actual shape but keep aligned backing storage
+            self.attn_bias = bias_full[:, :q_len, :k_len]
+
+            print("Unknown attention type used, only support `self_attention` and `cross_attention`")
+
+    def get_attn_bias(self):
+        return self.attn_bias
+
 # xFormers Attention
 class DecoderXFormersAttention(nn.Module):
-    def __init__(self, n_head, d_k, d_model, temperature):
+    def __init__(self, n_head, d_k, d_model, temperature, attention_type):
         super().__init__()
         self.temperature = temperature
         self.n_head = n_head
         self.d_k = d_k
         self.d_model = d_model
-        self.scale = 1.0 / temperature
+        self.attention_metadata = XFormersAttentionMetadata(attention_type)
 
     def forward(self, q, k, v, mask=None):
         original_query = q
         bs = q.size(0)
-        q_len = q.size(1)  # seq_len_q
-        k_len = k.size(1)  # seq_len_k
+        # Save lengths
+        q_len = q.size(2)  # seq_len_q
+        k_len = k.size(2)  # seq_len_k
+        dtype = q.dtype
 
-        # Reshape and add batch dimension for input of xformers memory_efficient_attention_forward
-        q = q.reshape(-1, self.n_head, self.d_k).unsqueeze(0).half()
-        k = k.reshape(-1, self.n_head, self.d_k).unsqueeze(0).half()
-        v = v.reshape(-1, self.n_head, self.d_k).unsqueeze(0).half()
+        q = q.reshape(bs * self.n_head, -1, self.d_k).to(torch.bfloat16)
+        k = k.reshape(bs * self.n_head, -1, self.d_k).to(torch.bfloat16)
+        v = v.reshape(bs * self.n_head, -1, self.d_k).to(torch.bfloat16)
 
         output = None
         if bs == 1:
-            output = xops.memory_efficient_attention_forward(q,
-                                                             k,
-                                                             v,
-                                                             scale=self.scale,
-                                                             op=xops.fmha.ck.FwOp)
+            output = xops.memory_efficient_attention(q, k, v)
         else:
             attn_bias = None
-            # --- Detect if it is causal self-attention ---
+            # --- AUTO-DETECT causal self-attention ---
             # q and k are the same tensor object in memory when this is pure self-attn
-            if q_len == k_len and q.data_ptr() == k.data_ptr():
-                attn_bias = BlockDiagonalCausalMask.from_seqlens([q_len] * bs, device=q.device)
+            if self.attention_metadata.attention_type == "self_attention":
+                attn_bias = xops.LowerTriangularMask()
 
             # --- Cross-attention / padding mask ---
-            elif mask is not None:
-                encoder_seq_lens = [mask[i].flatten().sum() for i in range(mask.shape[0])]
-                attn_bias = BlockDiagonalMask.from_seqlens([q_len] * bs, encoder_seq_lens, device=q.device)
-            # print("==========================================")
-            # print("attn_bias: ", attn_bias)
-            # print("query.shape: ", query.shape)
-            # print("key.shape: ", key.shape)
-            # print("value.shape: ", value.shape)
-            # print("\n")
-            output = xops.memory_efficient_attention_forward(
-                q,
-                k,
-                v,
-                attn_bias=attn_bias,
-                scale=self.scale,
-                op=xops.fmha.ck.FwOp)
+            #elif mask is not None:
+            elif self.attention_metadata.attention_type == "cross_attention" and mask is not None:
+                if self.attention_metadata.get_attn_bias() == None:
+                    self.attention_metadata.set_cross_attn_bias(mask, bs, q_len, k_len)
+                attn_bias = self.attention_metadata.get_attn_bias()
 
-        return output.view_as(original_query).to(original_query.dtype)
+            # --- Run memory-efficient attention ---
+            output = xops.memory_efficient_attention(q, k, v,
+                                                    attn_bias=attn_bias if attn_bias is not None else None)
+
+        # reshape back to (bs, seq_len, d_model)
+        return output.view_as(original_query).to(dtype)
 
 
 class PositionwiseFeedForward(nn.Module):

--- a/fireredasr/models/module/transformer_decoder.py
+++ b/fireredasr/models/module/transformer_decoder.py
@@ -377,7 +377,7 @@ class DecoderXFormersAttention(nn.Module):
                 scale=self.scale,
                 op=xops.fmha.ck.FwOp)
 
-        return output.view_as(original_query)
+        return output.view_as(original_query).to(original_query.dtype)
 
 
 class PositionwiseFeedForward(nn.Module):

--- a/fireredasr/models/module/transformer_decoder.py
+++ b/fireredasr/models/module/transformer_decoder.py
@@ -6,8 +6,6 @@ import torch.nn.functional as F
 from torch import Tensor
 import math
 import os
-import torch
-import torch.nn as nn
 
 try:
     import xformers.ops as xops

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ peft>=0.13.2
 sentencepiece
 torch>=2.0.0
 transformers>=4.46.3
+librosa


### PR DESCRIPTION
Hi FireRedTeam, thanks for your great work! 

This PR aims to add FireRedASR optimization on ROCm on target platform AMD Instinct MI300+ GPU. 
- Add `docker/Dockerfile.rocm` to quickly setup ROCm7 environment for deployment
- Add Pytorch SDPA and xFormer Attention support for performance optimization, can be controlled by environment variable: `ATTENTION_BACKEND="SDPA"` and `ATTENTION_BACKEND="XFORMERS"`
- Fix torch.load issue with `weight_only=False` for torch >= 2.6
- Add benchmark scripts and torch profiling support for performance analysis of different attention backend. 
- Add FireRedASR optimization on ROCm guide in README.md.

Here are performance results with example audio (batch size=1) on single MI308X for your reference: 
ATTENTION_BACKEND | RTF | Performance   gain vs Native
-- | -- | --
Native | 0.063 | /
Torch SDPA | 0.048 | 23.81%
xFormers   Attention | 0.056 | 11.11%
